### PR TITLE
Add libexpat dep for voting system

### DIFF
--- a/nix/shell.nix
+++ b/nix/shell.nix
@@ -1,4 +1,4 @@
-pkgs@{ callPackage, mkShell, qemu, which, netcat, xxd, ps, tcl }:
+pkgs@{ callPackage, mkShell, qemu, which, netcat, xxd, ps, expat, tcl }:
 
 let
   besspin = callPackage ./besspin-pkgs.nix {};
@@ -43,6 +43,9 @@ in mkShell {
     
     testgenUnpacker
     tcl
+
+    # For building Voting system
+    expat
   ];
 
   FETT_GFE_SCRIPT_DIR = "${besspin.testingScripts}/scripts";


### PR DESCRIPTION
- This PR is just to add `expat` to the fett environment. This library is required to build a voting system dependency.