### PR TITLE
add pynacl to fettPython3

### DIFF
--- a/nix/shell.nix
+++ b/nix/shell.nix
@@ -11,6 +11,7 @@ let
     scapy
     tftpy
     psutil
+    pynacl
   ]);
 
 in mkShell {


### PR DESCRIPTION
We need `pynacl` for the ED25519 signing utility.