### PR TITLE
Add curl to nix shell

### DIFF
--- a/nix/shell.nix
+++ b/nix/shell.nix
@@ -1,4 +1,4 @@
-pkgs@{ callPackage, mkShell, qemu, which, netcat, xxd, ps, expat, tcl }:
+pkgs@{ callPackage, mkShell, qemu, which, netcat, xxd, ps, expat, tcl, curl }:
 
 let
   besspin = callPackage ./besspin-pkgs.nix {};
@@ -41,6 +41,7 @@ in mkShell {
     netcat
     xxd
     ps
+    curl
     
     testgenUnpacker
     tcl


### PR DESCRIPTION
This PR adds `curl` to the FETT nix shell. When looking at DARPA-SSITH-Demonstrators/SSITH-FETT-Target#260, the only test causing problems for me was HTTP2. That test seems to pass with this version of `curl`.