### PR TITLE
Expose FreeBSD sysroot in Nix shell

### DIFF
--- a/nix/shell.nix
+++ b/nix/shell.nix
@@ -61,6 +61,7 @@ in mkShell {
   FETT_GFE_FREEBSD_DEBUG_QEMU = besspin.freebsdDebugImageQemu;
   FETT_GFE_BUSYBOX_FPGA = besspin.busyboxImage;
   FETT_GFE_BUSYBOX_QEMU = besspin.busyboxImageQemu;
+  FETT_GFE_FREEBSD_SYSROOT = besspin.freebsdSysroot;
 
   cachePackages = with besspin; [
     testingScripts


### PR DESCRIPTION
This PR adds an environment variable `FETT_GFE_FREEBSD_SYSROOT`, which points to the nix store path of our FreeBSD sysroot. That way we don't have to run GCC to locate it.