### PR TITLE
Add PAM and libkeyutils headers to CPATH

### DIFF
--- a/nix/shell.nix
+++ b/nix/shell.nix
@@ -99,4 +99,5 @@ in mkShell {
     freebsdElfConnectal
     freebsdImageConnectal
   ];
+  CPATH = with besspin; "${riscv-libkeyutils}/include:${riscv-libpam}/include";
 }


### PR DESCRIPTION
This PR adds the PAM and libkeyutils headers to CPATH.  It is necessary for building the PPAC CWE tests.