### PR TITLE
Fix debian firesim poweroff

### DIFF
--- a/nix/gfe/riscv-bbl.nix
+++ b/nix/gfe/riscv-bbl.nix
@@ -23,7 +23,10 @@ stdenv.mkDerivation rec {
 
   makeFlags = lib.optional (gfePlatform == "qemu") "TARGET_QEMU=yes";
 
-  patches = lib.optional (gfePlatform == "firesim") ./riscv-pk-firesim-uart.patch;
+  patches = lib.optional (gfePlatform == "firesim") [ 
+      ./riscv-pk-firesim-uart.patch
+      ./riscv-pk-firesim-poweroff.patch
+      ];
 
   installPhase = ''
     cp bbl $out

--- a/nix/gfe/riscv-pk-firesim-poweroff.patch
+++ b/nix/gfe/riscv-pk-firesim-poweroff.patch
@@ -1,0 +1,20 @@
+diff --git a/machine/htif.c b/machine/htif.c
+index 5f8722f..def0a3f 100644
+--- a/machine/htif.c
++++ b/machine/htif.c
+@@ -143,14 +143,5 @@ static void htif_done(const struct fdt_scan_node *node, void *extra)
+ 
+ void query_htif(uintptr_t fdt)
+ {
+-  struct fdt_cb cb;
+-  struct htif_scan scan;
+-
+-  memset(&cb, 0, sizeof(cb));
+-  cb.open = htif_open;
+-  cb.prop = htif_prop;
+-  cb.done = htif_done;
+-  cb.extra = &scan;
+-
+-  fdt_scan(fdt, &cb);
++  htif = 1;
+ }


### PR DESCRIPTION
The current debian image does not actually poweroff FireSim. Hardcoding `htif` seems to solve it. It's stolen from [this diff](https://github.com/riscv/riscv-pk/compare/riscv:5d9ed238e1cabfbca3c47f50d32894ce94bfc304...cad3deb357d25773a22e2c346ef464d3d66dd37c)