### PR TITLE
Get the keyring souce from the archives instead of the snapshots mirror

### DIFF
--- a/nix/misc/debian-ports-archive-keyring.nix
+++ b/nix/misc/debian-ports-archive-keyring.nix
@@ -1,28 +1,24 @@
-{ stdenv, fetchurl, gnupg }:
+{ stdenv, fetchurl, dpkg }:
 
 stdenv.mkDerivation rec {
   name = "debian-ports-archive-keyring-${version}";
   version = "2018.12.27";
 
   src = fetchurl {
-    url = "mirror://debian/pool/main/d/debian-ports-archive-keyring/debian-ports-archive-keyring_${version}.tar.xz";
-    sha256 = "10sjghh2yj789mg8fypiihhjvsbyylrbnbpirznm3zcqy0k514xg";
+    url = "https://snapshot.debian.org/archive/debian-ports/20181231T220243Z/pool/main/d/debian-ports-archive-keyring/debian-ports-archive-keyring_${version}_all.deb";
+    sha256 = "15vspxdzd2b8r54gzyhhdd5hy1kj7902ww31w5cshpds3rbx0h3x";
   };
 
-  buildInputs = [ gnupg ];
+  buildInputs = [ dpkg ];
 
-  # Taken from debian/rules
-  buildPhase = ''
-    GPG_OPTIONS="--no-options --no-default-keyring --no-auto-check-trustdb"
+  phases = [ "unpackPhase" "installPhase" ];
 
-    # Build keyrings
-    mkdir -p build/keyrings
-    gpg $GPG_OPTIONS --no-keyring --import-options import-export --import active-keys/* > build/keyrings/debian-ports-archive-keyring.gpg
-    gpg $GPG_OPTIONS --no-keyring --import-options import-export --import removed-keys/* > build/keyrings/debian-ports-archive-keyring-removed.gpg
+  unpackPhase = ''
+        dpkg -x ${src} .
   '';
 
   installPhase = ''
     mkdir -p $out/share
-    cp -r build/keyrings $out/share/keyrings
+    cp -r usr/share/keyrings $out/share/keyrings
   '';
 }


### PR DESCRIPTION
Closes DARPA-SSITH-Demonstrators/SSITH-FETT-Target#944