### PR TITLE
Prepare repo for purge of verific

### DIFF
--- a/nix/besspin-pkgs.nix
+++ b/nix/besspin-pkgs.nix
@@ -170,15 +170,6 @@ let
 
     # Other dependencies - binaries and C/C++ libraries.
 
-    verific_2018_06 = callPackage cxx/verific.nix {
-      # We explicitly want an old revision of Verific here.  Halcyon only works
-      # with version 2018-06.
-      version = "2018-06";
-      rev = "71ecf0524b1084ac55368cd8881b864ec7092c69";
-      sha256 = "0ljdpqcnhp8yf82xq9hv457rvbagvl7wjzlqyfhlp7ria9skwn9a";
-    };
-    verific = callPackage cxx/verific.nix {};
-
     tinycbor = callPackage cxx/tinycbor.nix {};
 
     # Csmith, built from the galois `bof` branch.
@@ -289,12 +280,11 @@ let
     };
 
     halcyonSrc = callPackage besspin/halcyon-src.nix {};
-    halcyon = togglePackageDisabled "verific" "besspin-halcyon"
-      (callPackage besspin/halcyon.nix {
-        # Halcyon uses the `PrettyPrintXML` function, which was removed after the
-        # June 2018 release of Verific.
-        verific = verific_2018_06;
-      });
+    halcyon = pkgs.writeShellScriptBin "besspin-halcyon"
+      ''
+        echo "besspin-halcyon no longer builds in nix due to the removal of verific.""
+        false
+      '';
 
     testgenSrc = callPackage besspin/testgen-src.nix {};
     testgenUnpacker = unpacker {
@@ -328,8 +318,11 @@ let
 
     aeSrc = callPackage besspin/arch-extract-src.nix {};
     aeDriver = callPackage besspin/arch-extract-driver.nix {};
-    aeExportVerilog = togglePackageDisabled "verific" "besspin-arch-extract-export-verilog"
-      (callPackage besspin/arch-extract-export-verilog.nix {});
+    aeExportVerilog = pkgs.writeShellScriptBin "besspin-arch-extract-export-verilog"
+      ''
+        echo "besspin-arch-extract-export-verilog no longer builds in nix due to the removal of verific.""
+        false
+      '';
     bscSrc = callPackage ./bsc/src.nix {};
     bscExport = togglePackageDisabled "bsc" "bsc" (callPackage ./bsc {});
 

--- a/nix/default-user-config.nix
+++ b/nix/default-user-config.nix
@@ -76,7 +76,6 @@
   # do not have access to the source repositories, and thus will not be able
   # to build these packages.
   buildPrivate = {
-    verific = false;
     bsc = false;
   };
 
@@ -86,7 +85,6 @@
   # message. This is necessary if one wants to use the nix shell
   # without access to the source code or the binary cache.
   disabled = {
-    verific = false;
     bsc = false;
   };
 

--- a/nix/dev/arch-extract.nix
+++ b/nix/dev/arch-extract.nix
@@ -10,9 +10,7 @@ in mkShell {
     [
       aeDriver
       featuresynthWrapper   # for the racket dep
-    ]
-    ++ lib.optionals (besspin.config.buildPrivate.verific) [ aeExportVerilog verific ]
-  ;
+    ];
   buildInputs = with pkgs; with besspin; [
     python3
     racket


### PR DESCRIPTION
This PR removes references to `verific` so that `nix/cxx/verific.nix` may be purged.  I tested these changes by performing a full nix build with them (and with `nix/cxx/verific.nix` removed).

This PR should be merged before purging `verific` to avoid breaking the nix build.