### PR TITLE
Post release fixes due to public releasing

### DIFF
--- a/docker/fett-cheri/README.md
+++ b/docker/fett-cheri/README.md
@@ -57,7 +57,7 @@ sudo apt update
 sudo apt install -y git-all
 sudo apt install -y git-lfs
 sudo apt install -y awscli
-git clone https://github.com:GaloisInc/BESSPIN-Tool-Suite.git
+git clone https://github.com/GaloisInc/BESSPIN-Tool-Suite.git
 cd BESSPIN-Tool-Suite
 git submodule update --init
 cd BESSPIN-LFS

--- a/docker/gfe/Dockerfile
+++ b/docker/gfe/Dockerfile
@@ -236,7 +236,7 @@ RUN mkdir -p $SYSROOT/usr \
 
 # ------------------------ Build openocd ------------------------
 # This also needs to be changed prior to openocd
-RUN git clone https://github.com:GaloisInc/BESSPIN-riscv-openocd.git $OPENOCD_SRC \
+RUN git clone https://github.com/GaloisInc/BESSPIN-riscv-openocd.git $OPENOCD_SRC \
         && cd $OPENOCD_SRC \
         && git checkout 27c0fd7a7504087e6d8b6158a149b531bda9260d \
         && git submodule update --init --recursive \

--- a/docker/tool-suite/Dockerfile
+++ b/docker/tool-suite/Dockerfile
@@ -36,7 +36,7 @@ RUN mkdir -p -m 0700 ~/.ssh \
 # Populate the cache & prepare a copy of Tool-Suite
 RUN --mount=type=secret,id=galoisCredentialsNetrc,dst=/home/besspinuser/.config/nix/netrc,uid=1000 \
     # This should be updated prior to open source
-    git clone https://github.com:GaloisInc/BESSPIN-Tool-Suite.git \
+    git clone https://github.com/GaloisInc/BESSPIN-Tool-Suite.git \
     && cd $REPO_SRC \
     && git submodule update --init BESSPIN-Environment \
     # Run a dummy command to return from the shell automatically + populate the nix store

--- a/docker/ui/Dockerfile
+++ b/docker/ui/Dockerfile
@@ -18,14 +18,14 @@ EXPOSE 3784
 RUN sudo apt install -y sqlite3
 
 # clafer
-RUN git clone https://github.com:GaloisInc/BESSPIN-clafer.git clafer \
+RUN git clone https://github.com/GaloisInc/BESSPIN-clafer.git clafer \
     && cd clafer \
     && git checkout besspin-v1.0 \
     && curl -sSL https://get.haskellstack.org/ | sh \
     && stack install clafer
 
 # Besspin-ui repo
-RUN git clone https://github.com:GaloisInc/BESSPIN-UI.git ui \
+RUN git clone https://github.com/GaloisInc/BESSPIN-UI.git ui \
     && cd ui \
     && git checkout besspin-v1.0 \
     && pip3 install -r server/requirements.txt \

--- a/nix/besspin/arch-extract-src.nix
+++ b/nix/besspin/arch-extract-src.nix
@@ -1,6 +1,6 @@
 { fetchGit2 }:
 
 fetchGit2 {
-  url = "git@github.com:GaloisInc/BESSPIN-arch-extract.git";
+  url = "https://github.com/GaloisInc/BESSPIN-arch-extract.git";
   rev = "71008b9755f099986ed6a69736c2a676b0c404ec";
 }

--- a/nix/besspin/configurator.nix
+++ b/nix/besspin/configurator.nix
@@ -4,7 +4,7 @@ srcOnly {
   name = "besspin-configurator";
 
   src = fetchGit2 {
-    url = "git@github.com:GaloisInc/BESSPIN-UI.git";
+    url = "https://github.com/GaloisInc/BESSPIN-UI.git";
     rev = "559985b1e1cec1915e1d8356dbb60dfb4d28f151";
     ref = "master";
   };

--- a/nix/besspin/coremark-src.nix
+++ b/nix/besspin/coremark-src.nix
@@ -1,7 +1,7 @@
 { fetchGit2 }:
 
 fetchGit2 {
-  url = "git@github.com:GaloisInc/BESSPIN-coremark.git";
+  url = "https://github.com/GaloisInc/BESSPIN-coremark.git";
   rev = "10c0b7a0e5341693be3381c5dbea94840247649a";
   ref = "ssith";
 }

--- a/nix/besspin/halcyon-src.nix
+++ b/nix/besspin/halcyon-src.nix
@@ -1,6 +1,6 @@
 { fetchGit2 }:
 
 fetchGit2 {
-  url = "git@github.com:GaloisInc/BESSPIN-halcyon.git";
+  url = "https://github.com/GaloisInc/BESSPIN-halcyon.git";
   rev = "783f30d3eb4f700f14e3752c03b8bb0132e93f4c";
 }

--- a/nix/besspin/mibench-src.nix
+++ b/nix/besspin/mibench-src.nix
@@ -1,7 +1,7 @@
 { fetchGit2 }:
 
 fetchGit2 {
-  url = "git@github.com:GaloisInc/BESSPIN-mibench2.git";
+  url = "https://github.com/GaloisInc/BESSPIN-mibench2.git";
   rev = "e3582f259ea226540e4bf514b23741b0c5cb038f";
   ref = "ssith";
 }

--- a/nix/besspin/riscv-timing-tests-src.nix
+++ b/nix/besspin/riscv-timing-tests-src.nix
@@ -1,6 +1,6 @@
 { fetchGit2 }:
 
 fetchGit2 {
-  url = "git@github.com:GaloisInc/BESSPIN-riscv-timing-tests.git";
+  url = "https://github.com/GaloisInc/BESSPIN-riscv-timing-tests.git";
   rev = "8b4042adaa1dde7b00373ab391bb67b01591322c";
 }

--- a/nix/bsc/src.nix
+++ b/nix/bsc/src.nix
@@ -5,7 +5,7 @@
 let
   fetch' = name: rev: args: fetchGit2 ({
     name = "${name}-private";
-    url = "git@github.com:GaloisInc/${name}.git";
+    url = "https://github.com/GaloisInc/${name}.git";
     inherit rev;
   } // args);
 

--- a/nix/bsc/src.nix
+++ b/nix/bsc/src.nix
@@ -14,7 +14,7 @@ let
 in assembleSubmodules {
   name = "bsc-src-private";
   modules = {
-    "." = fetch' "BESSPIN-BSC" "9d2ddd747cf793b3ee275a141bb6c5e657d60ae2" {
+    "." = fetch' "BESSPIN-BSC" "823376c3704d08e00736bad36c7e1737ec2899dd" {
       ref = "ast-export";
     };
   };

--- a/nix/default-user-config.nix
+++ b/nix/default-user-config.nix
@@ -128,24 +128,24 @@
   gitSrcs = {
     # Use the HEAD commit of `~/repo1` instead of fetching the pinned
     # revision from Github.
-    #"git@github.com:GaloisInc/repo1.git" = "/home/me/repo1";
+    #"https://github.com/GaloisInc/repo1.git" = "/home/me/repo1";
 
     # Use the HEAD commit of `~/repo2`, but only to replace commit
     # `00112233445566778899aabbccddeeff00112233`.  Other references to
     # `repo2` will continue to use the pinned revision.
-    #"git@github.com:GaloisInc/repo2.git#00112233445566778899aabbccddeeff00112233" ="/home/me/repo2";
+    #"https://github.com/GaloisInc/repo2.git#00112233445566778899aabbccddeeff00112233" ="/home/me/repo2";
 
     # Fetch revision `aabbccddeeff0011223300112233445566778899` from
     # `my-branch` Github, instead of using the normal pinned revision.
-    #"git@github.com:GaloisInc/repo3.git" = {
-    #  url = "git@github.com:GaloisInc/repo3.git";
+    #"https://github.com/GaloisInc/repo3.git" = {
+    #  url = "https://github.com/GaloisInc/repo3.git";
     #  rev = "aabbccddeeff0011223300112233445566778899";
     #  ref = "my-branch";
     #};
 
     # Use the HEAD commit of `~/repo4`, but only when building `some-package`.
     # All other packages will use the normal URL.
-    #"git@github.com:GaloisInc/repo4.git%some-package" = "/home/me/repo4";
+    #"https://github.com/GaloisInc/repo4.git%some-package" = "/home/me/repo4";
   };
 
   # If set, each Git fetch will be reported on stderr during the Nix build

--- a/nix/gfe/gfe-src.nix
+++ b/nix/gfe/gfe-src.nix
@@ -18,7 +18,7 @@ let
   # specific default branch.
   fetchSsith = name: ref: rev: args: fetchGit2 ({
     name = "${name}-source";
-    url = "git@github.com:GaloisInc/${name}.git";
+    url = "https://github.com/GaloisInc/${name}.git";
     inherit rev ref context;
   } // args);
 

--- a/nix/haskell/clafer-0.4.5.nix
+++ b/nix/haskell/clafer-0.4.5.nix
@@ -10,7 +10,7 @@ mkDerivation {
   pname = "clafer";
   version = "0.4.5";
   src = fetchGit2 {
-    url = "git@github.com:GaloisInc/BESSPIN-clafer.git";
+    url = "https://github.com/GaloisInc/BESSPIN-clafer.git";
     rev = "14fedb21c3df5d61b1deb5aa83a377be01ca4804";
   };
   isLibrary = true;

--- a/nix/haskell/clafer-0.5-besspin.nix
+++ b/nix/haskell/clafer-0.5-besspin.nix
@@ -10,7 +10,7 @@ mkDerivation {
   pname = "clafer";
   version = "0.5.1";
   src = fetchGit2 {
-   url = "git@github.com:GaloisInc/BESSPIN-clafer.git";
+   url = "https://github.com/GaloisInc/BESSPIN-clafer.git";
    rev = "a7194d859b442ee08cdc718783e36da535e4dd88";
   };
   isLibrary = true;

--- a/nix/haskell/clafer-0.5.0.nix
+++ b/nix/haskell/clafer-0.5.0.nix
@@ -10,7 +10,7 @@ mkDerivation {
   pname = "clafer";
   version = "0.5.0";
   src = fetchGit2 {
-    url = "git@github.com:GaloisInc/BESSPIN-clafer.git";
+    url = "https://github.com/GaloisInc/BESSPIN-clafer.git";
     rev = "23c7b41eca220dc62d05c065a6e9cdb3637586a9";
   };
   isLibrary = true;

--- a/nix/misc/riscv-openocd.nix
+++ b/nix/misc/riscv-openocd.nix
@@ -5,7 +5,7 @@
 let
   modules = {
     "." = fetchGit2 {
-      url = "git@github.com:GaloisInc/BESSPIN-riscv-openocd.git";
+      url = "https://github.com/GaloisInc/BESSPIN-riscv-openocd.git";
       rev = "27c0fd7a7504087e6d8b6158a149b531bda9260d";
       ref = "gfe";
     };

--- a/nix/racket/bdd.nix
+++ b/nix/racket/bdd.nix
@@ -4,7 +4,7 @@ mkRacketDerivation rec {
   pname = "bdd";
   version = "0.1";
   src = fetchGit2 {
-    url = "git@github.com:pcerman/bdd-racket.git";
+    url = "https://github.com/pcerman/bdd-racket.git";
     rev = "4edba235b632b4d9fdaf991c24168f1e76023b55";
   };
 


### PR DESCRIPTION
Context: I have made many blind updates as I could not test them while the repos were private. So I am not surprised at all that I have missed some subtleties. This PR fixes those.

Disclaimer: The `tool-suite` docker image still cannot build, even using the Dockerfile in this PR, because it fetches BESSPIN-Tool-Suite from github, and thus fetches BESSPIN-Environment that the tool-suite `master` is pointing at. The ssh vs https links within the Nix source codes are the culprit here. In order to push the image to Dockerhub, I hacked the Dockerfile and pointed to this branch.

Changes:
- Use https instead of ssh in all Nix codes.
- When I changed ssh to https in all git links in the Dockerfiles, I have not changed `githum.com:` to `github.com/`. This is fixed here.